### PR TITLE
Add Reaktivasi summary endpoint with role-scoped status counts

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -95,6 +95,7 @@ $routes->post('saveInactive', 'Dtks\Pbi\Inactive::saveInactive', ['filter' => 'a
 $routes->post('editInactive', 'Dtks\Pbi\Inactive::formEditInactive', ['filter' => 'authfilterdtks', 'filter' => 'menufilterdtks']);
 $routes->post('updateInactive', 'Dtks\Pbi\Inactive::updateInactive', ['filter' => 'authfilterdtks', 'filter' => 'menufilterdtks']);
 $routes->post('dltInactive', 'Dtks\Pbi\Inactive::hapus', ['filter' => 'authfilterdtks', 'filter' => 'menufilterdtks']);
+$routes->get('pbi/reaktivasi/summary', 'Dtks\Pbi\Reaktivasi::summary');
 
 // USULAN
 $routes->get('usulan', 'Dtks\Usulan22::index', ['filter' => 'authfilterdtks', 'filter' => 'menufilterdtks']);

--- a/app/Controllers/Dtks/Pbi/Reaktivasi.php
+++ b/app/Controllers/Dtks/Pbi/Reaktivasi.php
@@ -1,0 +1,427 @@
+<?php
+
+namespace App\Controllers\Dtks\Pbi;
+
+use App\Controllers\BaseController;
+use App\Models\PbiReaktivasiModel;
+
+class Reaktivasi extends BaseController
+{
+    protected $model;
+
+    private const ROLE_KECAMATAN = 2;
+    private const ROLE_DESA = 3;
+    private const ROLE_PENTRI = 4;
+
+    public function __construct()
+    {
+        $this->model = new PbiReaktivasiModel();
+    }
+
+    public function index()
+    {
+        return view('dtks/pbi/reaktivasi/index');
+    }
+
+    public function create()
+    {
+        return view('dtks/pbi/reaktivasi/create');
+    }
+
+    public function store()
+    {
+        if (session('role_id') !== self::ROLE_PENTRI) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Unauthorized',
+            ]);
+        }
+
+        $rules = [
+            'nik' => 'required|min_length[16]',
+            'nama_snapshot' => 'required',
+            'alasan' => 'required',
+        ];
+
+        if (! $this->validate($rules)) {
+            return $this->response->setJSON([
+                'success' => false,
+                'errors' => $this->validator->getErrors(),
+            ]);
+        }
+
+        $file = $this->request->getFile('surat_faskes');
+
+        if (! $file || ! $file->isValid() || $file->hasMoved()) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'File tidak valid (hanya PDF/JPG/PNG, max 2MB)',
+            ]);
+        }
+
+        $allowedMimeTypes = ['application/pdf', 'image/jpeg', 'image/png'];
+
+        if ($file->getSize() > 2048 * 1024 || ! in_array($file->getMimeType(), $allowedMimeTypes, true)) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'File tidak valid (hanya PDF/JPG/PNG, max 2MB)',
+            ]);
+        }
+
+        $uploadDir = WRITEPATH . '../public/uploads/pbi/';
+        if (! is_dir($uploadDir)) {
+            mkdir($uploadDir, 0775, true);
+        }
+
+        $newName = $file->getRandomName();
+        $file->move(FCPATH . 'uploads/pbi/', $newName);
+
+        $data = [
+            'nik' => $this->request->getPost('nik'),
+            'nama_snapshot' => $this->request->getPost('nama_snapshot'),
+            'status_pbi_awal' => $this->request->getPost('status_pbi_awal'),
+            'desil_snapshot' => $this->request->getPost('desil_snapshot'),
+            'alasan' => $this->request->getPost('alasan'),
+            'kondisi_mendesak' => $this->request->getPost('kondisi_mendesak') ?? 0,
+            'surat_faskes' => $newName,
+            'status_pengajuan' => PbiReaktivasiModel::STATUS_DRAFT,
+            'tanggal_draft' => date('Y-m-d H:i:s'),
+            'created_by' => session('user_id'),
+            'desa_id' => session('desa_id'),
+        ];
+
+        $this->model->insert($data);
+
+        return $this->response->setJSON([
+            'success' => true,
+            'message' => 'Draft berhasil disimpan.',
+            'id' => $this->model->getInsertID(),
+        ]);
+    }
+
+
+    public function tabel_data()
+    {
+        $draw = (int) ($this->request->getVar('draw') ?? 0);
+        $start = (int) ($this->request->getVar('start') ?? 0);
+        $length = (int) ($this->request->getVar('length') ?? 10);
+        $search = $this->request->getVar('search');
+        $order = $this->request->getVar('order');
+        $columns = $this->request->getVar('columns');
+
+        $roleId = (int) session('role_id');
+        if (! in_array($roleId, [self::ROLE_PENTRI, self::ROLE_DESA, self::ROLE_KECAMATAN], true)) {
+            return $this->response->setJSON([
+                'draw' => $draw,
+                'recordsTotal' => 0,
+                'recordsFiltered' => 0,
+                'data' => [],
+            ]);
+        }
+
+        $baseBuilder = $this->model->builder();
+        $this->applyRoleFilter($baseBuilder, $roleId);
+        $recordsTotal = (clone $baseBuilder)->countAllResults();
+
+        $searchValue = trim((string) ($search['value'] ?? ''));
+        if ($searchValue !== '') {
+            $baseBuilder->groupStart()
+                ->like('nik', $searchValue)
+                ->orLike('nama_snapshot', $searchValue)
+                ->orLike('alasan', $searchValue)
+                ->groupEnd();
+        }
+
+        $recordsFiltered = (clone $baseBuilder)->countAllResults();
+
+        $allowedOrderColumns = ['id', 'nik', 'nama_snapshot', 'status_pengajuan', 'created_at'];
+        $orderColumn = 'id';
+        $orderDir = 'DESC';
+
+        if (is_array($order) && isset($order[0]['column'], $order[0]['dir']) && is_array($columns)) {
+            $columnIndex = (int) $order[0]['column'];
+            $requestedColumn = $columns[$columnIndex]['data'] ?? '';
+            $requestedDir = strtolower((string) $order[0]['dir']);
+
+            if (in_array($requestedColumn, $allowedOrderColumns, true)) {
+                $orderColumn = $requestedColumn;
+            }
+
+            if (in_array($requestedDir, ['asc', 'desc'], true)) {
+                $orderDir = strtoupper($requestedDir);
+            }
+        }
+
+        $baseBuilder->select('*')->orderBy($orderColumn, $orderDir);
+
+        if ($length !== -1) {
+            $baseBuilder->limit($length, $start);
+        }
+
+        $result = $baseBuilder->get()->getResultArray();
+
+        return $this->response->setJSON([
+            'draw' => $draw,
+            'recordsTotal' => $recordsTotal,
+            'recordsFiltered' => $recordsFiltered,
+            'data' => $result,
+        ]);
+    }
+
+
+    public function summary()
+    {
+        $roleId = (int) session('role_id');
+
+        if (! in_array($roleId, [self::ROLE_PENTRI, self::ROLE_DESA, self::ROLE_KECAMATAN], true)) {
+            return $this->response->setJSON([
+                'draft' => 0,
+                'diajukan' => 0,
+                'diverifikasi' => 0,
+                'disetujui' => 0,
+                'ditolak' => 0,
+                'diajukan_siks' => 0,
+            ]);
+        }
+
+        $draft = $this->countByStatus($roleId, PbiReaktivasiModel::STATUS_DRAFT);
+        $diajukan = $this->countByStatus($roleId, PbiReaktivasiModel::STATUS_DIAJUKAN);
+        $diverifikasi = $this->countByStatus($roleId, PbiReaktivasiModel::STATUS_DIVERIFIKASI);
+        $disetujui = $this->countByStatus($roleId, PbiReaktivasiModel::STATUS_DISETUJUI);
+        $ditolak = $this->countByStatus($roleId, PbiReaktivasiModel::STATUS_DITOLAK);
+        $diajukanSiks = $this->countByStatus($roleId, PbiReaktivasiModel::STATUS_DIAJUKAN_SIKS);
+
+        return $this->response->setJSON([
+            'draft' => $draft,
+            'diajukan' => $diajukan,
+            'diverifikasi' => $diverifikasi,
+            'disetujui' => $disetujui,
+            'ditolak' => $ditolak,
+            'diajukan_siks' => $diajukanSiks,
+        ]);
+    }
+
+    private function countByStatus(int $roleId, int $status): int
+    {
+        $builder = $this->model->builder();
+        $this->applyRoleFilter($builder, $roleId);
+        $builder->where('status_pengajuan', $status);
+
+        return (int) $builder->countAllResults();
+    }
+
+    private function applyRoleFilter($builder, int $roleId): void
+    {
+        if ($roleId === self::ROLE_PENTRI) {
+            $builder->where('created_by', (int) session('user_id'));
+            return;
+        }
+
+        if ($roleId === self::ROLE_DESA) {
+            $builder->where('desa_id', (int) session('desa_id'));
+        }
+    }
+
+    public function submit($id)
+    {
+        if (session('role_id') !== self::ROLE_PENTRI) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Unauthorized',
+            ]);
+        }
+
+        $record = $this->model->find($id);
+
+        if (! $record) {
+            return $this->response->setJSON(['success' => false, 'message' => 'Data tidak ditemukan']);
+        }
+
+        if ((int) $record['created_by'] !== (int) session('user_id')) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Unauthorized',
+            ]);
+        }
+
+        if ((int) $record['status_pengajuan'] !== PbiReaktivasiModel::STATUS_DRAFT) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Status tidak valid untuk diajukan.',
+            ]);
+        }
+
+        $this->model->update($id, [
+            'status_pengajuan' => PbiReaktivasiModel::STATUS_DIAJUKAN,
+            'tanggal_diajukan' => date('Y-m-d H:i:s'),
+        ]);
+
+        return $this->response->setJSON([
+            'success' => true,
+            'message' => 'Pengajuan berhasil dikirim.',
+        ]);
+    }
+
+    public function verify($id)
+    {
+        if (session('role_id') !== self::ROLE_DESA) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Unauthorized',
+            ]);
+        }
+
+        $record = $this->model->find($id);
+
+        if (! $record) {
+            return $this->response->setJSON(['success' => false, 'message' => 'Data tidak ditemukan']);
+        }
+
+        if ((int) $record['desa_id'] !== (int) session('desa_id')) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Unauthorized',
+            ]);
+        }
+
+        if ((int) $record['status_pengajuan'] !== PbiReaktivasiModel::STATUS_DIAJUKAN) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Status tidak valid untuk diverifikasi.',
+            ]);
+        }
+
+        $this->model->update($id, [
+            'status_pengajuan' => PbiReaktivasiModel::STATUS_DIVERIFIKASI,
+            'tanggal_verifikasi' => date('Y-m-d H:i:s'),
+            'verified_by' => session('user_id'),
+        ]);
+
+        return $this->response->setJSON([
+            'success' => true,
+            'message' => 'Data berhasil diverifikasi.',
+        ]);
+    }
+
+    public function approve($id)
+    {
+        if (session('role_id') !== self::ROLE_DESA) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Unauthorized',
+            ]);
+        }
+
+        $record = $this->model->find($id);
+
+        if (! $record) {
+            return $this->response->setJSON(['success' => false, 'message' => 'Data tidak ditemukan']);
+        }
+
+        if ((int) $record['desa_id'] !== (int) session('desa_id')) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Unauthorized',
+            ]);
+        }
+
+        if ((int) $record['status_pengajuan'] !== PbiReaktivasiModel::STATUS_DIVERIFIKASI) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Status tidak valid untuk disetujui.',
+            ]);
+        }
+
+        $this->model->update($id, [
+            'status_pengajuan' => PbiReaktivasiModel::STATUS_DISETUJUI,
+            'tanggal_keputusan' => date('Y-m-d H:i:s'),
+            'keputusan_by' => session('user_id'),
+        ]);
+
+        return $this->response->setJSON([
+            'success' => true,
+            'message' => 'Pengajuan disetujui.',
+        ]);
+    }
+
+    public function reject($id)
+    {
+        if (session('role_id') !== self::ROLE_DESA) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Unauthorized',
+            ]);
+        }
+
+        $record = $this->model->find($id);
+
+        if (! $record) {
+            return $this->response->setJSON(['success' => false, 'message' => 'Data tidak ditemukan']);
+        }
+
+        if ((int) $record['desa_id'] !== (int) session('desa_id')) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Unauthorized',
+            ]);
+        }
+
+        if ((int) $record['status_pengajuan'] !== PbiReaktivasiModel::STATUS_DIVERIFIKASI) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Status tidak valid untuk ditolak.',
+            ]);
+        }
+
+        $this->model->update($id, [
+            'status_pengajuan' => PbiReaktivasiModel::STATUS_DITOLAK,
+            'tanggal_keputusan' => date('Y-m-d H:i:s'),
+            'keputusan_by' => session('user_id'),
+        ]);
+
+        return $this->response->setJSON([
+            'success' => true,
+            'message' => 'Pengajuan ditolak.',
+        ]);
+    }
+
+    public function kirimSiks($id)
+    {
+        if (session('role_id') !== self::ROLE_DESA) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Unauthorized',
+            ]);
+        }
+
+        $record = $this->model->find($id);
+
+        if (! $record) {
+            return $this->response->setJSON(['success' => false, 'message' => 'Data tidak ditemukan']);
+        }
+
+        if ((int) $record['desa_id'] !== (int) session('desa_id')) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Unauthorized',
+            ]);
+        }
+
+        if ((int) $record['status_pengajuan'] !== PbiReaktivasiModel::STATUS_DISETUJUI) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => 'Status tidak valid untuk dikirim ke SIKS.',
+            ]);
+        }
+
+        $this->model->update($id, [
+            'status_pengajuan' => PbiReaktivasiModel::STATUS_DIAJUKAN_SIKS,
+            'tanggal_kirim_siks' => date('Y-m-d H:i:s'),
+        ]);
+
+        return $this->response->setJSON([
+            'success' => true,
+            'message' => 'Data berhasil dikirim ke SIKS.',
+        ]);
+    }
+}

--- a/app/Database/Migrations/2026-02-19-105233_PbiReaktivasi.php
+++ b/app/Database/Migrations/2026-02-19-105233_PbiReaktivasi.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class PbiReaktivasi extends Migration
+{
+	public function up()
+	{
+		$this->forge->addField([
+			'id' => [
+				'type' => 'INT',
+				'constraint' => 11,
+				'unsigned' => true,
+				'auto_increment' => true,
+			],
+			'nik' => [
+				'type' => 'VARCHAR',
+				'constraint' => 20,
+			],
+			'nama_snapshot' => [
+				'type' => 'VARCHAR',
+				'constraint' => 150,
+			],
+			'status_pbi_awal' => [
+				'type' => 'ENUM',
+				'constraint' => ['aktif', 'nonaktif'],
+			],
+			'desil_snapshot' => [
+				'type' => 'INT',
+				'constraint' => 11,
+			],
+			'alasan' => [
+				'type' => 'TEXT',
+			],
+			'kondisi_mendesak' => [
+				'type' => 'TINYINT',
+				'constraint' => 1,
+				'default' => 0,
+			],
+			'surat_faskes' => [
+				'type' => 'VARCHAR',
+				'constraint' => 255,
+			],
+			'status_pengajuan' => [
+				'type' => 'TINYINT',
+				'constraint' => 1,
+				'default' => 0,
+			],
+			'catatan_pentri' => [
+				'type' => 'TEXT',
+				'null' => true,
+			],
+			'catatan_desa' => [
+				'type' => 'TEXT',
+				'null' => true,
+			],
+			'tanggal_draft' => [
+				'type' => 'DATETIME',
+				'null' => true,
+			],
+			'tanggal_diajukan' => [
+				'type' => 'DATETIME',
+				'null' => true,
+			],
+			'tanggal_verifikasi' => [
+				'type' => 'DATETIME',
+				'null' => true,
+			],
+			'tanggal_keputusan' => [
+				'type' => 'DATETIME',
+				'null' => true,
+			],
+			'tanggal_kirim_siks' => [
+				'type' => 'DATETIME',
+				'null' => true,
+			],
+			'tanggal_respon_kab' => [
+				'type' => 'DATETIME',
+				'null' => true,
+			],
+			'created_by' => [
+				'type' => 'INT',
+				'constraint' => 11,
+				'unsigned' => true,
+			],
+			'verified_by' => [
+				'type' => 'INT',
+				'constraint' => 11,
+				'unsigned' => true,
+				'null' => true,
+			],
+			'keputusan_by' => [
+				'type' => 'INT',
+				'constraint' => 11,
+				'unsigned' => true,
+				'null' => true,
+			],
+			'desa_id' => [
+				'type' => 'INT',
+				'constraint' => 11,
+				'unsigned' => true,
+			],
+			'created_at' => [
+				'type' => 'DATETIME',
+				'null' => true,
+			],
+			'updated_at' => [
+				'type' => 'DATETIME',
+				'null' => true,
+			],
+		]);
+
+		$this->forge->addKey('id', true);
+		$this->forge->addKey('nik');
+		$this->forge->addKey('status_pengajuan');
+		$this->forge->addKey('desa_id');
+		$this->forge->createTable('pbi_reaktivasi');
+	}
+
+	public function down()
+	{
+		$this->forge->dropTable('pbi_reaktivasi');
+	}
+}

--- a/app/Models/PbiReaktivasiModel.php
+++ b/app/Models/PbiReaktivasiModel.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class PbiReaktivasiModel extends Model
+{
+    public const STATUS_DRAFT = 0;
+    public const STATUS_DIAJUKAN = 1;
+    public const STATUS_DIVERIFIKASI = 2;
+    public const STATUS_DISETUJUI = 3;
+    public const STATUS_DITOLAK = 4;
+    public const STATUS_DIAJUKAN_SIKS = 5;
+    public const STATUS_DISETUJUI_KAB = 6;
+    public const STATUS_DITOLAK_KAB = 7;
+
+    protected $table = 'pbi_reaktivasi';
+    protected $primaryKey = 'id';
+    protected $useTimestamps = true;
+
+    protected $allowedFields = [
+        'nik',
+        'nama_snapshot',
+        'status_pbi_awal',
+        'desil_snapshot',
+        'alasan',
+        'kondisi_mendesak',
+        'surat_faskes',
+        'status_pengajuan',
+        'catatan_pentri',
+        'catatan_desa',
+        'tanggal_draft',
+        'tanggal_diajukan',
+        'tanggal_verifikasi',
+        'tanggal_keputusan',
+        'tanggal_kirim_siks',
+        'tanggal_respon_kab',
+        'created_by',
+        'verified_by',
+        'keputusan_by',
+        'desa_id',
+        'created_at',
+        'updated_at',
+    ];
+
+    public function getStatusLabel(int $status): string
+    {
+        $labels = [
+            self::STATUS_DRAFT => 'Draft',
+            self::STATUS_DIAJUKAN => 'Diajukan',
+            self::STATUS_DIVERIFIKASI => 'Diverifikasi',
+            self::STATUS_DISETUJUI => 'Disetujui',
+            self::STATUS_DITOLAK => 'Ditolak',
+            self::STATUS_DIAJUKAN_SIKS => 'Diajukan SIKS',
+            self::STATUS_DISETUJUI_KAB => 'Disetujui Kab',
+            self::STATUS_DITOLAK_KAB => 'Ditolak Kab',
+        ];
+
+        return $labels[$status] ?? 'Status tidak dikenal';
+    }
+}

--- a/app/Views/dtks/pbi/reaktivasi/index.php
+++ b/app/Views/dtks/pbi/reaktivasi/index.php
@@ -1,0 +1,181 @@
+<?= $this->extend('templates/index'); ?>
+
+<?= $this->section('content'); ?>
+<div class="content-wrapper mt-1">
+    <section class="content pt-2">
+        <div class="container-fluid">
+            <div class="card card-outline card-primary">
+                <div class="card-header">
+                    <h3 class="card-title mb-0">Reaktivasi PBI</h3>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table id="tabelReaktivasi" class="table table-sm table-hover table-striped w-100">
+                            <thead>
+                                <tr>
+                                    <th>No</th>
+                                    <th>NIK</th>
+                                    <th>Nama</th>
+                                    <th>Status</th>
+                                    <th>Mendesak</th>
+                                    <th>Tanggal Draft</th>
+                                    <th>Aksi</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+
+<script>
+    const ROLE_ID = <?= (int) session('role_id') ?>;
+
+    function getStatusBadge(status) {
+        const badgeClassMap = {
+            0: 'secondary',
+            1: 'warning',
+            2: 'info',
+            3: 'success',
+            4: 'danger',
+            5: 'primary'
+        };
+
+        const statusLabelMap = {
+            0: 'Draft',
+            1: 'Diajukan',
+            2: 'Diverifikasi',
+            3: 'Disetujui',
+            4: 'Ditolak',
+            5: 'Diajukan SIKS',
+            6: 'Disetujui Kab',
+            7: 'Ditolak Kab'
+        };
+
+        const badgeClass = badgeClassMap[status] || 'dark';
+        const label = statusLabelMap[status] || 'Tidak diketahui';
+        return `<span class="badge badge-${badgeClass}">${label}</span>`;
+    }
+
+    function getActionButtons(row) {
+        const status = Number(row.status_pengajuan);
+        const id = row.id;
+        let buttons = '';
+
+        if (ROLE_ID === 4 && status === 0) {
+            buttons += `<button type="button" class="btn btn-xs btn-warning btn-action" data-url="/pbi/reaktivasi/submit/${id}" data-confirm="Ajukan data ini?">Ajukan</button>`;
+        }
+
+        if (ROLE_ID === 3 && status === 1) {
+            buttons += `<button type="button" class="btn btn-xs btn-info btn-action" data-url="/pbi/reaktivasi/verify/${id}" data-confirm="Verifikasi data ini?">Verifikasi</button>`;
+        }
+
+        if (ROLE_ID === 3 && status === 2) {
+            buttons += `<button type="button" class="btn btn-xs btn-success btn-action mr-1" data-url="/pbi/reaktivasi/approve/${id}" data-confirm="Setujui data ini?">Setujui</button>`;
+            buttons += `<button type="button" class="btn btn-xs btn-danger btn-action" data-url="/pbi/reaktivasi/reject/${id}" data-confirm="Tolak data ini?">Tolak</button>`;
+        }
+
+        if (ROLE_ID === 3 && status === 3) {
+            buttons += `<button type="button" class="btn btn-xs btn-primary btn-action" data-url="/pbi/reaktivasi/kirimSiks/${id}" data-confirm="Kirim data ke SIKS?">Kirim SIKS</button>`;
+        }
+
+        return buttons || '-';
+    }
+
+    $(function() {
+        const table = $('#tabelReaktivasi').DataTable({
+            processing: true,
+            serverSide: true,
+            searching: true,
+            order: [
+                [0, 'desc']
+            ],
+            ajax: {
+                url: '/pbi/reaktivasi/tabel',
+                type: 'POST'
+            },
+            columns: [{
+                    data: 'id',
+                    orderable: false,
+                    render: function(data, type, row, meta) {
+                        return meta.row + meta.settings._iDisplayStart + 1;
+                    }
+                },
+                {
+                    data: 'nik'
+                },
+                {
+                    data: 'nama_snapshot'
+                },
+                {
+                    data: 'status_pengajuan',
+                    render: function(data) {
+                        return getStatusBadge(Number(data));
+                    }
+                },
+                {
+                    data: 'kondisi_mendesak',
+                    render: function(data) {
+                        if (Number(data) === 1) {
+                            return '<span class="badge badge-danger">Mendesak</span>';
+                        }
+
+                        return '<span class="badge badge-light">Normal</span>';
+                    }
+                },
+                {
+                    data: 'tanggal_draft',
+                    defaultContent: '-'
+                },
+                {
+                    data: null,
+                    orderable: false,
+                    searchable: false,
+                    render: function(data, type, row) {
+                        return getActionButtons(row);
+                    }
+                }
+            ]
+        });
+
+        $('#tabelReaktivasi').on('click', '.btn-action', function() {
+            const url = $(this).data('url');
+            const confirmText = $(this).data('confirm') || 'Lanjutkan proses?';
+
+            Swal.fire({
+                title: 'Konfirmasi',
+                text: confirmText,
+                icon: 'question',
+                showCancelButton: true,
+                confirmButtonText: 'Ya, lanjutkan',
+                cancelButtonText: 'Batal'
+            }).then((result) => {
+                if (!result.isConfirmed) {
+                    return;
+                }
+
+                $.ajax({
+                    url: url,
+                    type: 'POST',
+                    dataType: 'json',
+                    success: function(response) {
+                        if (response.success) {
+                            Swal.fire('Berhasil', response.message || 'Aksi berhasil.', 'success');
+                            table.ajax.reload(null, false);
+                            return;
+                        }
+
+                        Swal.fire('Gagal', response.message || 'Proses gagal.', 'error');
+                    },
+                    error: function() {
+                        Swal.fire('Error', 'Terjadi kesalahan pada server.', 'error');
+                    }
+                });
+            });
+        });
+    });
+</script>
+<?= $this->endSection(); ?>


### PR DESCRIPTION
### Motivation

- Provide a lightweight summary endpoint that returns counts per lifecycle status for Reaktivasi records to support dashboard/UI summaries.
- Ensure counts are computed via the model query builder (no raw SQL) and are scoped by user role (Pentri, Desa, Kecamatan) to respect data visibility rules.
- Centralize status constants and metadata in a model so controller logic uses the canonical status values.

### Description

- Add `App\Controllers\Dtks\Pbi\Reaktivasi` controller implementing CRUD, status-transition actions, and a new `summary()` method that uses the model query builder (`$this->model->builder()`) to count records per status.
- Implement `countByStatus()` helper and `applyRoleFilter()` that applies role-based filters: Pentri → `created_by = session('user_id')`, Desa → `desa_id = session('desa_id')`, Kecamatan → no extra filter.
- Add `App\Models\PbiReaktivasiModel` with status constants (`STATUS_DRAFT`, `STATUS_DIAJUKAN`, `STATUS_DIVERIFIKASI`, `STATUS_DISETUJUI`, `STATUS_DITOLAK`, `STATUS_DIAJUKAN_SIKS`, etc.) and allowed fields used by the controller.
- Add DB migration `2026-02-19-105233_PbiReaktivasi.php`, view `app/Views/dtks/pbi/reaktivasi/index.php`, and route `pbi/reaktivasi/summary` pointing to `Dtks\Pbi\Reaktivasi::summary`.

### Testing

- Ran `php -l app/Controllers/Dtks/Pbi/Reaktivasi.php` and it reported no syntax errors.
- Ran `php -l app/Config/Routes.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996eb577fb88323af18d4ab368ef1f6)